### PR TITLE
diskovery: update to 0.9.11.0

### DIFF
--- a/bucket/diskovery.json
+++ b/bucket/diskovery.json
@@ -2,12 +2,12 @@
     "homepage": "https://diskovery.io/",
     "description": "Data storage inspection tool",
     "license": "Freeware",
-    "version": "0.9.10.0",
-    "url": "https://diskovery.io/get",
-    "hash": "fcdaa9bf6269829b0000e348e2b2cef848d854575f81466b70e3c93cd2f8fae1",
+    "version": "0.9.11.0",
+    "url": "https://diskovery.io/get#/diskovery-0.9.11.0.exe",
+    "hash": "b384eb4289d31d845fe73261e5a550b5445b29bcc74bad0233e4836198c3a958",
     "shortcuts": [
         [
-            "diskovery-0.9.10.0.exe",
+            "diskovery-0.9.11.0.exe",
             "Diskovery"
         ]
     ],


### PR DESCRIPTION
The url gets downloaded into a file named `get` so I had to add the `#/diskovery-version.exe` part